### PR TITLE
Add Google Scholar IDs to RETROSPECT and HiRes

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -68,6 +68,7 @@
   year={2026},
   selected={true},
   category={workshop},
+  google_scholar_id={UebtZRa9Y70C},
 }
 
 @inproceedings{openMolGen2024,
@@ -156,6 +157,7 @@
   selected={true},
   category={preprint},
   url={https://arxiv.org/abs/2605.21420},
+  google_scholar_id={Se3iqnhoufwC},
 }
 
 @misc{CountCLIP2024,


### PR DESCRIPTION
Follow-up to #13. The RETROSPECT and HiRes bib entries were missing the
`google_scholar_id` field, so the Scholar tab/badge didn't render on those
two publications.

This adds the real IDs (already present in `_data/citations.yml`):
- **RETROSPECT** → `UebtZRa9Y70C`
- **HiRes** → `Se3iqnhoufwC`

Both papers now show the Scholar badge like the rest of the publications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)